### PR TITLE
captrs #4 - used geometry fn to return expected output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ impl Capturer {
 
     /// Returns the width and height of the area to capture
     #[cfg(windows)]
-    pub fn geometry(&mut self) -> (u32, u32) {
+    pub fn geometry(&self) -> (u32, u32) {
         let (w, h) = self.dxgi_manager.geometry();
         (w as u32, h as u32)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,8 +94,9 @@ impl Capturer {
 
     /// Returns the width and height of the area to capture
     #[cfg(windows)]
-    pub fn geometry(&self) -> (u32, u32) {
-        (self.width as u32, self.height as u32)
+    pub fn geometry(&mut self) -> (u32, u32) {
+        let (w, h) = self.dxgi_manager.geometry();
+        (w as u32, h as u32)
     }
 
     /// Returns the width and height of the area to capture


### PR DESCRIPTION
#4 
Just to make your life easier https://github.com/bryal/dxgcap-rs/pull/9#issue-527798539

This fixes (with the help of the PR on dxgcap-rs) the (0, 0) return value.
